### PR TITLE
Fix bitnami download link

### DIFF
--- a/puppet/modules/bitnamistack/manifests/params.pp
+++ b/puppet/modules/bitnamistack/manifests/params.pp
@@ -1,7 +1,7 @@
 class bitnamistack::params {
 
     $install_file = "bitnami-lampstack-1.2-5-linux-installer.run"
-    $download_install_path = "http://bitnami.org/files/download/$bitnamistack::params::install_file"
+    $download_install_path = "http://bitnami.org/files/download/lamp/$bitnamistack::params::install_file"
     $stack_full_path = "/home/vagrant/lampstack"
 
 }


### PR DESCRIPTION
The old download link gives a 404, this one works.
